### PR TITLE
Evita que o match apresente valores NaN

### DIFF
--- a/client/src/actions/candidatosActions.js
+++ b/client/src/actions/candidatosActions.js
@@ -294,7 +294,13 @@ export const atualizaScore = ({ idPergunta, respostaAnterior }) => (
         }
       }
     } 
-    scoreCandidatos[elem] = votosIguaisUsuarioCandidatos[elem] / numRespostasConsideradas;
+
+    if (numRespostasConsideradas === 0) {
+      scoreCandidatos[elem] = 0;      
+    } else {
+      scoreCandidatos[elem] = votosIguaisUsuarioCandidatos[elem] / numRespostasConsideradas;
+    }
+          
   });
 
   dispatch({


### PR DESCRIPTION
Quando não existem perguntas com respostas do usuário e do candidato o match calculado é de 0.