### PR TITLE
Adiciona comissões na interface

### DIFF
--- a/client/src/components/candidatos/Candidato.js
+++ b/client/src/components/candidatos/Candidato.js
@@ -17,7 +17,7 @@ class Candidato extends Component {
 
     const badgeNaoTemVotacoes = (
       <span style={{ marginLeft: "5px" }}
-        className="badge badge-secondary">não atuou</span>
+        className="badge badge-light">não atuou</span>
     );
 
     const verAtuacao = (
@@ -36,37 +36,35 @@ class Candidato extends Component {
     );
 
     const filtraComissoes = (comissoes) => {
-      let comissoes_titular = comissoes.
-        filter(comissao => comissao.cargo !== "Suplente");
-
       let comissoes_suplente = comissoes.
         filter(comissao => comissao.cargo === "Suplente");
 
-      let comissoes_filtradas = comissoes_titular;
+      let comissoes_filtradas = comissoes.
+      filter(comissao => comissao.cargo !== "Suplente");
 
       if (comissoes_filtradas.length === 0) {
         comissoes_filtradas = comissoes_suplente;
 
-      } else if (comissoes_filtradas.length < 3 && comissoes_suplente.length > 0) {
+      } else if (comissoes_filtradas.length <= 3 && comissoes_suplente.length > 0) {
         comissoes_filtradas.push.apply(comissoes_filtradas, comissoes_suplente);
       }
 
       if (comissoes_filtradas.length > 3) {
         let restantes = comissoes_filtradas.length - 3;
-        let outras_comissoes = {
-          comissao_id: "0",
-          cargo: "",
-          info_comissao: {
-            sigla: "+ " + restantes,
-            nome: restantes > 1 ?
-              "O parlamentar é suplente em mais outras " + restantes + " comissões." :
-              "O parlamentar é suplente em mais uma " + restantes + " comissão."
+        if (restantes > 1) {
+          let outras_comissoes = {
+            comissao_id: "0",
+            cargo: "",
+            info_comissao: {
+              sigla: "+ " + restantes,
+              nome: "O/A parlamentar participa de mais " + restantes + " comissões."
+            }
           }
+          comissoes_filtradas = comissoes_filtradas.slice(0, 3);
+          comissoes_filtradas.push(outras_comissoes);
         }
-        comissoes_filtradas = comissoes_filtradas.slice(0, 3);
-        comissoes_filtradas.push(outras_comissoes);
       }
-      return (comissoes_filtradas);
+      return (comissoes_filtradas.slice(0, 4));
     };
 
     const naoRespondeu = (
@@ -88,8 +86,8 @@ class Candidato extends Component {
             props.comissao.info_comissao.nome :
             props.comissao.cargo + ' na ' + props.comissao.info_comissao.nome}
           </Tooltip>}>
-        <span style={{ marginRight: "5px" }}
-          className="badge badge-success"> {props.comissao.info_comissao.sigla}
+        <span style={{ marginRight: "5px" }} className="badge badge-success suplente">
+          {props.comissao.info_comissao.sigla}
         </span>
       </OverlayTrigger>
     );
@@ -164,7 +162,7 @@ class Candidato extends Component {
                       style={{
                         marginLeft: "5px"
                       }}
-                      className="badge badge-success"
+                      className="badge badge-secondary"
                     >
                       reeleito/a
                     </span>

--- a/client/src/components/candidatos/Candidato.js
+++ b/client/src/components/candidatos/Candidato.js
@@ -16,7 +16,7 @@ class Candidato extends Component {
     );
 
     const badgeNaoTemVotacoes = (
-      <span style={{ marginRight: "5px" }}
+      <span style={{ marginLeft: "5px" }}
         className="badge badge-secondary">não atuou</span>
     );
 
@@ -59,8 +59,8 @@ class Candidato extends Component {
           info_comissao: {
             sigla: "+ " + restantes,
             nome: restantes > 1 ?
-            "O parlamentar participa de mais outras " + restantes + " comissões." :
-            "O parlamentar participa de mais uma " + restantes + " comissão."
+              "O parlamentar é suplente em mais outras " + restantes + " comissões." :
+              "O parlamentar é suplente em mais uma " + restantes + " comissão."
           }
         }
         comissoes_filtradas = comissoes_filtradas.slice(0, 3);
@@ -84,9 +84,9 @@ class Candidato extends Component {
     const TitularComissao = (props) => (
       <OverlayTrigger
         overlay={
-          <Tooltip> {props.comissao.comissao_id === "0"? 
-          props.comissao.info_comissao.nome : 
-          props.comissao.cargo + ' na ' + props.comissao.info_comissao.nome}
+          <Tooltip> {props.comissao.comissao_id === "0" ?
+            props.comissao.info_comissao.nome :
+            props.comissao.cargo + ' na ' + props.comissao.info_comissao.nome}
           </Tooltip>}>
         <span style={{ marginRight: "5px" }}
           className="badge badge-success"> {props.comissao.info_comissao.sigla}
@@ -149,11 +149,11 @@ class Candidato extends Component {
                 <h5 className="person-name">{this.props.nome}</h5>
                 <div>
                   {this.props.siglaPartido}/{this.props.estado}
-                </div>
-                <div className="pb-1">
                   {this.props.reeleicao && !this.props.reeleito && (
                     <span
-                      style={{ marginRight: "5px" }}
+                      style={{
+                        marginLeft: "5px"
+                      }}
                       className="badge badge-success"
                     >
                       reeleição
@@ -161,22 +161,25 @@ class Candidato extends Component {
                   )}
                   {this.props.reeleito && (
                     <span
-                      style={{ marginRight: "5px" }}
+                      style={{
+                        marginLeft: "5px"
+                      }}
                       className="badge badge-success"
                     >
                       reeleito/a
                     </span>
                   )}
                   {!this.props.temHistorico && badgeNaoTemVotacoes}
+                </div>
+                <div className="pb-1">
                   {filtraComissoes(this.props.comissoes).
                     map(comissao =>
                       <TitularComissao key={comissao.comissao_id} comissao={comissao} />
-                    )} 
-
+                    )}
+                  {this.props.temHistorico
+                    ? barraScore
+                    : naoRespondeu}
                 </div>
-                {this.props.temHistorico
-                  ? barraScore
-                  : naoRespondeu}
               </div>
             </div>
           </div>

--- a/client/src/components/candidatos/Candidato.js
+++ b/client/src/components/candidatos/Candidato.js
@@ -37,34 +37,26 @@ class Candidato extends Component {
 
     const filtraComissoes = (comissoes) => {
       let comissoes_suplente = comissoes.
-        filter(comissao => comissao.cargo === "Suplente");
+        filter(comissao => comissao.cargo === "Suplente").
+        length;
 
       let comissoes_filtradas = comissoes.
-      filter(comissao => comissao.cargo !== "Suplente");
+        filter(comissao => comissao.cargo !== "Suplente");
 
-      if (comissoes_filtradas.length === 0) {
-        comissoes_filtradas = comissoes_suplente;
-
-      } else if (comissoes_filtradas.length <= 3 && comissoes_suplente.length > 0) {
-        comissoes_filtradas.push.apply(comissoes_filtradas, comissoes_suplente);
-      }
-
-      if (comissoes_filtradas.length > 3) {
-        let restantes = comissoes_filtradas.length - 3;
-        if (restantes > 1) {
-          let outras_comissoes = {
-            comissao_id: "0",
-            cargo: "",
-            info_comissao: {
-              sigla: "+ " + restantes,
-              nome: "O/A parlamentar participa de mais " + restantes + " comissões."
-            }
+      if (comissoes_suplente > 0) {
+        let outras_comissoes = {
+          comissao_id: "0",
+          cargo: "",
+          info_comissao: {
+            sigla: "+ " + comissoes_suplente,
+            nome: comissoes_suplente == 1 ? 
+            "O/A parlamentar é suplente em " + comissoes_suplente + " comissão." : 
+            "O/A parlamentar é suplente em " + comissoes_suplente + " comissões."
           }
-          comissoes_filtradas = comissoes_filtradas.slice(0, 3);
-          comissoes_filtradas.push(outras_comissoes);
         }
+        comissoes_filtradas.push(outras_comissoes);
       }
-      return (comissoes_filtradas.slice(0, 4));
+      return (comissoes_filtradas);
     };
 
     const naoRespondeu = (

--- a/client/src/components/candidatos/Candidato.js
+++ b/client/src/components/candidatos/Candidato.js
@@ -16,7 +16,8 @@ class Candidato extends Component {
     );
 
     const badgeNaoTemVotacoes = (
-      <span className="badge badge-secondary">não atuou</span>
+      <span style={{ marginRight: "5px" }}
+        className="badge badge-secondary">não atuou</span>
     );
 
     const verAtuacao = (
@@ -34,6 +35,40 @@ class Candidato extends Component {
       </Link>
     );
 
+    const filtraComissoes = (comissoes) => {
+      let comissoes_titular = comissoes.
+        filter(comissao => comissao.cargo !== "Suplente");
+
+      let comissoes_suplente = comissoes.
+        filter(comissao => comissao.cargo === "Suplente");
+
+      let comissoes_filtradas = comissoes_titular;
+
+      if (comissoes_filtradas.length === 0) {
+        comissoes_filtradas = comissoes_suplente;
+
+      } else if (comissoes_filtradas.length < 3 && comissoes_suplente.length > 0) {
+        comissoes_filtradas.push.apply(comissoes_filtradas, comissoes_suplente);
+      }
+
+      if (comissoes_filtradas.length > 3) {
+        let restantes = comissoes_filtradas.length - 3;
+        let outras_comissoes = {
+          comissao_id: "0",
+          cargo: "",
+          info_comissao: {
+            sigla: "+ " + restantes,
+            nome: restantes > 1 ?
+            "O parlamentar participa de mais outras " + restantes + " comissões." :
+            "O parlamentar participa de mais uma " + restantes + " comissão."
+          }
+        }
+        comissoes_filtradas = comissoes_filtradas.slice(0, 3);
+        comissoes_filtradas.push(outras_comissoes);
+      }
+      return (comissoes_filtradas);
+    };
+
     const naoRespondeu = (
       <div>
         <div>
@@ -44,6 +79,19 @@ class Candidato extends Component {
 
     const tooltip = (
       <Tooltip>Não existem respostas suficientes para o cálculo preciso do alinhamento</Tooltip>
+    );
+
+    const TitularComissao = (props) => (
+      <OverlayTrigger
+        overlay={
+          <Tooltip> {props.comissao.comissao_id === "0"? 
+          props.comissao.info_comissao.nome : 
+          props.comissao.cargo + ' na ' + props.comissao.info_comissao.nome}
+          </Tooltip>}>
+        <span style={{ marginRight: "5px" }}
+          className="badge badge-success"> {props.comissao.info_comissao.sigla}
+        </span>
+      </OverlayTrigger>
     );
 
     const barraScore = (
@@ -120,6 +168,11 @@ class Candidato extends Component {
                     </span>
                   )}
                   {!this.props.temHistorico && badgeNaoTemVotacoes}
+                  {filtraComissoes(this.props.comissoes).
+                    map(comissao =>
+                      <TitularComissao key={comissao.comissao_id} comissao={comissao} />
+                    )} 
+
                 </div>
                 {this.props.temHistorico
                   ? barraScore
@@ -139,11 +192,12 @@ Candidato.propTypes = {
   nome: PropTypes.string.isRequired,
   siglaPartido: PropTypes.string.isRequired,
   estado: PropTypes.string.isRequired,
-  score: PropTypes.number.isRequired,  
+  score: PropTypes.number.isRequired,
   foto: PropTypes.string.isRequired,
   respostasUsuario: PropTypes.instanceOf(Object),
   email: PropTypes.string.isRequired,
-  eleito: PropTypes.bool.isRequired
+  eleito: PropTypes.bool.isRequired,
+  comissoes: PropTypes.instanceOf(Object)
 };
 
 export default Candidato;

--- a/client/src/components/candidatos/CandidatosContainer.js
+++ b/client/src/components/candidatos/CandidatosContainer.js
@@ -302,7 +302,7 @@ class CandidatosContainer extends Component {
         : candidatosRanqueados;
 
     let totalCandAtuacao = 0;
-        
+
     const candidatos = candidatosMapeaveis.map(cpf => {
       const candidato = dadosCandidatos[cpf];
 
@@ -316,7 +316,7 @@ class CandidatosContainer extends Component {
             nome={candidato.nome_urna}
             siglaPartido={candidato.sg_partido}
             estado={candidato.uf}
-            score={scoreCandidatos[candidato.cpf]}            
+            score={scoreCandidatos[candidato.cpf]}
             foto={
               candidato.tem_foto
                 ? "https://s3-sa-east-1.amazonaws.com/fotoscandidatos2018/fotos_tratadas/img_" +
@@ -341,7 +341,7 @@ class CandidatosContainer extends Component {
       return null;
     });
 
-       const listaSelectPartidos = partidos.map(partido => (
+    const listaSelectPartidos = partidos.map(partido => (
       <option key={partido} value={partido}>
         {partido}
       </option>

--- a/client/src/components/candidatos/CandidatosContainer.js
+++ b/client/src/components/candidatos/CandidatosContainer.js
@@ -334,13 +334,14 @@ class CandidatosContainer extends Component {
             }
             eleito={candidato.eleito}
             temHistorico={votacoesCandidatos[candidato.cpf] !== undefined}
+            comissoes={candidato.cpf_comissoes}
           />
         );
       }
       return null;
     });
 
-    const listaSelectPartidos = partidos.map(partido => (
+       const listaSelectPartidos = partidos.map(partido => (
       <option key={partido} value={partido}>
         {partido}
       </option>

--- a/routes/api/respostas.js
+++ b/routes/api/respostas.js
@@ -112,7 +112,7 @@ router.get("/eleitos", (req, res) => {
         attributes: ["comissao_id", "cargo"],
         include: [
           {
-            attributes: ["sigla"],
+            attributes: ["sigla", "nome"],
             model: Comissoes,
             as: "info_comissao",
             required: false
@@ -198,6 +198,20 @@ router.get("/candidatos/:cpf", (req, res) => {
         model: Resposta,
         as: "cpf_resp",
         attributes: att_res
+      },
+      {
+        model: ComposicaoComissoes,
+        attributes: ["comissao_id", "cargo"],
+        include: [
+          {
+            attributes: ["sigla", "nome"],
+            model: Comissoes,
+            as: "info_comissao",
+            required: false
+          }
+        ],
+        as: "cpf_comissoes",
+        required: false
       }
     ],
     where: { cpf: req.params.cpf }
@@ -234,6 +248,20 @@ router.get("/estados/:uf/partidos", (req, res) => {
         model: Resposta,
         as: "cpf_resp",
         attributes: att_res
+      },
+      {
+        model: ComposicaoComissoes,
+        attributes: ["comissao_id", "cargo"],
+        include: [
+          {
+            attributes: ["sigla", "nome"],
+            model: Comissoes,
+            as: "info_comissao",
+            required: false
+          }
+        ],
+        as: "cpf_comissoes",
+        required: false
       }
     ],
     where: query
@@ -313,6 +341,20 @@ router.get("/estados/:uf", (req, res) => {
           model: Resposta,
           as: "cpf_resp",
           attributes: att_res
+        },
+        {
+          model: ComposicaoComissoes,
+          attributes: ["comissao_id", "cargo"],
+          include: [
+            {
+              attributes: ["sigla", "nome"],
+              model: Comissoes,
+              as: "info_comissao",
+              required: false
+            }
+          ],
+          as: "cpf_comissoes",
+          required: false
         }
       ],
       where: query
@@ -390,6 +432,20 @@ router.get("/estados/:uf/partidos/:sigla", (req, res) => {
           model: Resposta,
           as: "cpf_resp",
           attributes: att_res
+        },
+        {
+          model: ComposicaoComissoes,
+          attributes: ["comissao_id", "cargo"],
+          include: [
+            {
+              attributes: ["sigla", "nome"],
+              model: Comissoes,
+              as: "info_comissao",
+              required: false
+            }
+          ],
+          as: "cpf_comissoes",
+          required: false
         }
       ],
       where: { uf: req.params.uf, sg_partido: req.params.sigla }
@@ -597,6 +653,20 @@ router.get("/estados/:uf/eleitos", (req, res) => {
           model: Resposta,
           as: "cpf_resp",
           attributes: att_res
+        },
+        {
+          model: ComposicaoComissoes,
+          attributes: ["comissao_id", "cargo"],
+          include: [
+            {
+              attributes: ["sigla", "nome"],
+              model: Comissoes,
+              as: "info_comissao",
+              required: false
+            }
+          ],
+          as: "cpf_comissoes",
+          required: false
         }
       ],
       where: {


### PR DESCRIPTION
Esta PR modifica o leiaute, adicionando informações sobre as comissões que os parlamentares participam: 
 - Os primeiros badges correspondem às titularidade dos parlamentares em uma comissão; e 
 - o último exibe o número de comissões em que um deputado é suplente.

Além disso, também foram mudados os estilos dos badges de 'reeleito' e 'não atuou'.

No back-end, foram adicionadas as informações de comissões nas rotas de deputados e filtro de deputados