### PR TITLE
Resolve bug da repetição da opção Partidos no componente de filtro

### DIFF
--- a/client/src/app/main/alinhamento/filter/filter.component.ts
+++ b/client/src/app/main/alinhamento/filter/filter.component.ts
@@ -54,7 +54,9 @@ export class FilterComponent implements OnInit {
 
   onChangeEstado() {
     this.partidosFiltradosPorEstado = this.partidosPorEstado.filter(value => value.estado === this.estadoSelecionado)[0].partidos;
-    this.partidosFiltradosPorEstado.splice(0, 0, "Partidos");
+    
+    if (!this.partidosFiltradosPorEstado.includes("Partidos"))
+      this.partidosFiltradosPorEstado.splice(0, 0, "Partidos");
 
     if (!this.partidosFiltradosPorEstado.includes(this.partidoSelecionado)) {
       this.partidoSelecionado = "Partidos";


### PR DESCRIPTION
Antes ao selecionar um partido e mudar de estado a opção "Partidos" era duplicada.

Com este PR o problema foi resolvido.