### PR TITLE
Dispara evento para permitir que as imagens dos primeiros elementos doa lista do alinhamento sejam carregados

### DIFF
--- a/client/src/app/alinhamento/alinhamento.component.ts
+++ b/client/src/app/alinhamento/alinhamento.component.ts
@@ -49,6 +49,7 @@ export class AlinhamentoComponent implements OnInit, OnDestroy {
             .subscribe(
               parlamentares => {
                 this.parlamentares = parlamentares;
+                this.eventScroll();
                 if (this.parlamentares.length > 0) {
                   this.isLoading = false;
                 }
@@ -88,5 +89,11 @@ export class AlinhamentoComponent implements OnInit, OnDestroy {
   ngOnDestroy() {
     this.unsubscribe.next();
     this.unsubscribe.complete();
+  }
+
+  // Evento para carregar a foto dos primeiros parlamentares da lista
+  private eventScroll() {
+    window.scrollTo(window.scrollX, window.scrollY - 1);
+    window.scrollTo(window.scrollX, window.scrollY + 1);
   }
 }


### PR DESCRIPTION
Proposta baseada nessa discussão: https://github.com/tjoskar/ng-lazyload-image/issues/197
Resolve #231 