### PR TITLE
Executa o build no travis CI apenas para algumas branches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,10 @@ node_js:
   - "10"
 dist: trusty
 sudo: required
+branches:
+  only:
+  - master
+  - /^sprint-.*$/
 before_install:
   - cd client/
 install:


### PR DESCRIPTION
- Travis CI só executa o build para a branch master e para as branches iniciadas com "sprint"