### PR TITLE
Considera orientação null como voto liberado

### DIFF
--- a/client/src/app/parlamentar/votacao/votacao.component.ts
+++ b/client/src/app/parlamentar/votacao/votacao.component.ts
@@ -49,6 +49,9 @@ export class VotacaoComponent implements OnInit {
       case undefined:
         classes.push('voto-liberou');
         break;
+      case null:
+        classes.push('voto-liberou');
+        break;
       default:
         break;
     }


### PR DESCRIPTION
Precisa da aprovação prévia do PR https://github.com/analytics-ufcg/vozativa-dados/pull/82