### PR TITLE
Altera endpoints para considerar casa do parlamentar

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1496,6 +1496,27 @@
       "resolved": "https://registry.npmjs.org/express-unless/-/express-unless-0.3.1.tgz",
       "integrity": "sha1-JVfBRudb65A+LSR/m1ugFFJpbiA="
     },
+    "express-validator": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/express-validator/-/express-validator-6.2.0.tgz",
+      "integrity": "sha512-892cPistoSPzMuoG2p1W+2ZxBi0bAvPaaYgXK1E1C8/QncLo2d1HbiDDWkXUtTthjGEzEmwiELLJHu1Ez2hOEg==",
+      "requires": {
+        "lodash": "^4.17.15",
+        "validator": "^11.1.0"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+        },
+        "validator": {
+          "version": "11.1.0",
+          "resolved": "https://registry.npmjs.org/validator/-/validator-11.1.0.tgz",
+          "integrity": "sha512-qiQ5ktdO7CD6C/5/mYV4jku/7qnqzjrxb3C/Q5wR3vGGinHTgJZN/TdFT3ZX4vXhX2R1PXx42fB1cn5W+uJ4lg=="
+        }
+      }
+    },
     "extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "expand-range": "^2.0.2",
     "express": "^4.16.3",
     "express-jwt": "^5.3.1",
+    "express-validator": "^6.2.0",
     "fbgraph": "^1.4.4",
     "force-ssl-heroku": "^1.0.2",
     "heroku-logger": "^0.3.1",

--- a/routes/api/comissoes.js
+++ b/routes/api/comissoes.js
@@ -10,7 +10,6 @@ const models = require("../../models/index");
 const Comissoes = models.comissoes;
 const ComposicaoComissoes = models.composicaoComissoes;
 
-const sequelize = models.sequelize;
 
 /**
  * Recupera lista de Comissões

--- a/routes/api/comissoes.js
+++ b/routes/api/comissoes.js
@@ -1,22 +1,40 @@
 const express = require("express");
 const Sequelize = require("sequelize");
+const { validationResult } = require('express-validator');
 
 const router = express.Router();
+
+const casaValidator = require("../../utils/middlewares/casa.validator");
 
 const models = require("../../models/index");
 const Comissoes = models.comissoes;
 const ComposicaoComissoes = models.composicaoComissoes;
 
+const sequelize = models.sequelize;
+
 /**
  * Recupera lista de Comissões
  * @name get/api/comissoes/
  * @function
+ * @apiparam Casa Casa de origem do parlamentar. Pode ser "camara" (default) ou "senado".
  * @memberof module:routes/comissoes
  */
-router.get("/", (req, res) => {
+router.get("/", casaValidator.validate, (req, res) => {
+
+  const errors = validationResult(req);
+
+  if (!errors.isEmpty()) {
+    return res.status(400).json({ errors: errors.array() });
+  }
+
+  const casa = req.param("casa") || "camara"
+
   Comissoes.findAll({
     attributes: [["id_comissao_voz", "idComissaoVoz"], "sigla", "nome"],
-    order: ['nome']
+    order: ['nome'],
+    where: {
+      casa: casa
+    }
   })
     .then(comissoes => res.status(200).json(comissoes))
     .catch(err => res.status(400).json(err.message));
@@ -25,18 +43,38 @@ router.get("/", (req, res) => {
 /**
  * Recupera lista com parlamentares e Comissões
  * @name get/api/comissoes/composicao
+ * @apiparam Casa Casa de origem do parlamentar. Pode ser "camara" (default) ou "senado".
  * @function
  * @memberof module:routes/comissoes
  */
-router.get("/composicao", (req, res) => {
+router.get("/composicao", casaValidator.validate, (req, res) => {
+  const errors = validationResult(req);
+
+  if (!errors.isEmpty()) {
+    return res.status(400).json({ errors: errors.array() });
+  }
+
+  const casa = req.param("casa") || "camara"
+
   ComposicaoComissoes.findAll({
+    include: [
+      {
+        attributes: [],
+        model: Comissoes,        
+        as: "infoComissao",
+        required: true,
+        where: {
+          casa: casa
+        }
+      }
+    ]
   })
     .then(composicao => res.status(200).json(composicao))
     .catch(err => res.status(400).json(err.message));
 });
 
 /**
- * Recupera lista de membros das comissões
+ * Recupera lista de membros das comissões permamentes da Câmara e do Senado
  * @name get/api/comissoes/membros
  * @function
  * @memberof module:routes/comissoes
@@ -61,13 +99,35 @@ router.get("/membros", (req, res) => {
  * Recupera todos os tipos de cargos em comissões.
  * 
  * @name get/api/comissoes/cargos
+ * @apiparam Casa Casa de origem do parlamentar. Pode ser "camara" (default) ou "senado".
  * @function
  * @memberof module:routes/comissoes
  */
-router.get("/cargos", (req, res) => {
+router.get("/cargos", casaValidator.validate, (req, res) => {
+
+  const errors = validationResult(req);
+
+  if (!errors.isEmpty()) {
+    return res.status(400).json({ errors: errors.array() });
+  }
+
+  const casa = req.param("casa") || "camara"
+
   ComposicaoComissoes.findAll({
-    attributes: [[Sequelize.fn('DISTINCT', Sequelize.col('cargo')) ,'cargo']]
-  })
+    attributes: [[Sequelize.fn('DISTINCT', Sequelize.col('cargo')), 'cargo']],    
+    include: [
+      {
+        attributes: [],
+        model: Comissoes,        
+        as: "infoComissao",
+        required: true,
+        where: {
+          casa: casa
+        }
+      }
+    ],    
+    raw: true
+  })  
     .then(composicao => res.status(200).json(composicao))
     .catch(err => res.status(400).json(err.message));
 });

--- a/routes/api/parlamentares.js
+++ b/routes/api/parlamentares.js
@@ -108,10 +108,10 @@ router.get("/", (req, res) => {
 /**
  * Pega os partidos distintos de um estado
  * @name get/api/parlamentares/partidos
- * @param casa Casa de origem do deputado. Pode ser "camara" (default) ou "senado".
+ * @apiparam Casa Casa de origem do parlamentar. Pode ser "camara" (default) ou "senado".
  * @memberof module:routes/parlamentares 
  */
-router.get("/partidos", casaValidator.validaParametroCasa, (req, res) => {
+router.get("/partidos", casaValidator.validate, (req, res) => {
 
     const errors = validationResult(req);
 

--- a/utils/middlewares/casa.validator.js
+++ b/utils/middlewares/casa.validator.js
@@ -1,0 +1,13 @@
+const { check } = require('express-validator');
+
+module.exports = {
+  validaParametroCasa: [
+      check('casa').custom(casa => {
+        console.log(casa)        
+        if (casa !== undefined && casa !== "" && casa !== "camara" && casa !== "senado") {
+          throw new Error("Parâmetro casa precisa ser 'camara' ou 'senado'.");
+        }
+        return true;
+      })
+    ]  
+};

--- a/utils/middlewares/casa.validator.js
+++ b/utils/middlewares/casa.validator.js
@@ -2,8 +2,7 @@ const { check } = require('express-validator');
 
 module.exports = {
   validate: [
-      check('casa').custom(casa => {
-        console.log(casa)        
+      check('casa').custom(casa => {        
         if (casa !== undefined && casa !== "" && casa !== "camara" && casa !== "senado") {
           throw new Error("Parâmetro casa precisa ser 'camara' ou 'senado'.");
         }

--- a/utils/middlewares/casa.validator.js
+++ b/utils/middlewares/casa.validator.js
@@ -1,7 +1,7 @@
 const { check } = require('express-validator');
 
 module.exports = {
-  validaParametroCasa: [
+  validate: [
       check('casa').custom(casa => {
         console.log(casa)        
         if (casa !== undefined && casa !== "" && casa !== "camara" && casa !== "senado") {


### PR DESCRIPTION
## Changes
- Altera endpoints da API que listam propriedades que podem ser diferentes dependendo da casa de origem (camara ou senado)
  - A lista de endpoints alterados é:
    - /parlamentares/partidos
    - /comissoes
    - /liderancas
    - /comissoes/cargos
- Adiciona express-validator para realizar validação de parâmetros e tratamento de erros que ocorram caso a validação defina o parâmetro como incorreto.

## Flags
- Como uma nova depedência foi adicionada é preciso fazer o build novamente da imagem usada para desenvolvimento

## Issues
- Antes dos endpoints acima listados apenas retornavam dados referentes a Câmara dos deputados, agora é possível retornar também para o Senado Federal