### PR TITLE
Adiciona dados e endpoints relacionados ao perfil mais

### DIFF
--- a/models/index.js
+++ b/models/index.js
@@ -20,7 +20,8 @@ const LiderancasModel = "./postgres/liderancas.js";
 const ProposicaoTemasModel = "./postgres/proposicao_temas.js";
 const PartidoModel = "./postgres/partidos.js";
 const VotoModel = './postgres/voto.js';
-const OrientacaoModel = './postgres/orientacao.js'
+const OrientacaoModel = './postgres/orientacao.js';
+const PerfilMaisModel = './postgres/perfil-mais.js';
 
 if (!global.hasOwnProperty("models")) {
   const db = require("../config/keys").postgresURI;
@@ -62,7 +63,8 @@ if (!global.hasOwnProperty("models")) {
     proposicaoTemas: sequelize.import(ProposicaoTemasModel),
     partido: sequelize.import(PartidoModel),
     voto: sequelize.import(VotoModel),
-    orientacao: sequelize.import(OrientacaoModel)
+    orientacao: sequelize.import(OrientacaoModel),
+    perfilMais: sequelize.import(PerfilMaisModel)
     // add your other models here
   };
 

--- a/models/postgres/parlamentar.js
+++ b/models/postgres/parlamentar.js
@@ -48,6 +48,11 @@ module.exports = (sequelize, type) => {
         foreignKey: "id_parlamentar_voz",
         targetKey: "id_parlamentar_voz",      
         as: "parlamentarLiderancas"
+      }),      
+      parlamentar.hasOne(models.perfilMais, {
+        foreignKey: "id_parlamentar_voz",
+        targetKey: "id_parlamentar_voz",      
+        as: "parlamentarPerfilMais"
       }),
       parlamentar.belongsTo(models.partido, {
         foreignKey: "id_partido",

--- a/models/postgres/perfil-mais.js
+++ b/models/postgres/perfil-mais.js
@@ -1,0 +1,27 @@
+module.exports = (sequelize, type) => {
+    perfilMais = sequelize.define(
+      "perfil_mais",
+      {
+        id_parlamentar_voz: {
+          type: type.STRING,
+          primaryKey: true
+        },
+        indice_vinculo_economico_agro: type.REAL,
+        indice_ativismo_ambiental: type.REAL,
+        peso_politico: type.REAL
+      },
+      {
+        timestamps: false,
+        freezeTableName: true
+      }
+    );
+    perfilMais.associate = function (models) {
+      perfilMais.belongsTo(models.parlamentar, {
+        foreignKey: "id_parlamentar_voz",
+        sourceKey: "id_parlamentar_voz",
+        as: "perfilMaisParlamentar"
+      })
+    };
+    return perfilMais;
+  };
+  

--- a/routes/api/perfil.js
+++ b/routes/api/perfil.js
@@ -19,11 +19,11 @@ const attPartido = [["id_partido", "idPartido"], "sigla"]
 const attTema = [["id_tema", "idTema"], "tema", "slug"]
 
 /**
- * Recupera informações de um parlamentares e seus índices (incluindo aderência por tema) a partir de seu ID no Voz Ativa
+ * Recupera informações de um parlamentar e seus índices (incluindo aderência por tema) a partir de seu ID no Voz Ativa
  * 
  * @name get/api/perfil/:id
  * @function
- * @memberof module:routes/liderancas
+ * @memberof module:routes/perfil
  */
 router.get("/:id", (req, res) => {
   PerfilMais.findOne({
@@ -66,12 +66,12 @@ router.get("/:id", (req, res) => {
 });
 
 /**
- * Recupera informações de um parlamentares e seus índices (incluindo aderência por tema) a partir de uma lista de ID's 
- * passada no corpo da requisição.
+ * Recupera informações de uma lista de parlamentares e seus índices (incluindo aderência por tema) a partir de uma lista de ID's 
+ * passada no corpo da requisição. Exemplo: { "parlamentares": ["1160508", "1136811"] }
  * 
- * @name get/api/perfil/:id
+ * @name get/api/perfil/lista
  * @function
- * @memberof module:routes/liderancas
+ * @memberof module:routes/perfil
  */
 router.post("/lista", (req, res) => {
 

--- a/routes/api/perfil.js
+++ b/routes/api/perfil.js
@@ -1,0 +1,119 @@
+const express = require("express");
+
+const router = express.Router();
+
+const models = require("../../models/index");
+const PerfilMais = models.perfilMais;
+const Parlamentar = models.parlamentar;
+const Aderencia = models.aderencia;
+const Partido = models.partido;
+const Tema = models.tema;
+
+const BAD_REQUEST = 400;
+const SUCCESS = 200;
+
+const attPerfil = [["id_parlamentar_voz", "idParlamentarVoz"], ["peso_politico", "pesoPolitico"]]
+const attParlamentar = [["nome_eleitoral", "nomeEleitoral"], "casa"]
+const attAderencia = ["faltou", ["partido_liberou", "partidoLiberou"], ["nao_seguiu", "naoSeguiu"], "seguiu", "aderencia"];
+const attPartido = [["id_partido", "idPartido"], "sigla"]
+const attTema = [["id_tema", "idTema"], "tema", "slug"]
+
+/**
+ * Recupera informações de um parlamentares e seus índices (incluindo aderência por tema) a partir de seu ID no Voz Ativa
+ * 
+ * @name get/api/perfil/:id
+ * @function
+ * @memberof module:routes/liderancas
+ */
+router.get("/:id", (req, res) => {
+  PerfilMais.findOne({
+    attributes: attPerfil,
+    include: [
+      {
+        attributes: attParlamentar,
+        model: Parlamentar,
+        as: "perfilMaisParlamentar",
+        include: [
+          {
+            attributes: attAderencia,
+            model: Aderencia,
+            as: "parlamentarAderencia",
+            required: false,
+            include: [
+              {
+                attributes: attPartido,
+                model: Partido,
+                as: "partido",
+                required: false,
+              },
+              {
+                attributes: attTema,
+                model: Tema,
+                as: "aderenciaTema",
+                required: false
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    where: {
+      id_parlamentar_voz: req.params.id
+    }
+  })
+    .then(parlamentar => res.status(SUCCESS).json(parlamentar))
+    .catch(err => res.status(BAD_REQUEST).json({ err }));
+});
+
+/**
+ * Recupera informações de um parlamentares e seus índices (incluindo aderência por tema) a partir de uma lista de ID's 
+ * passada no corpo da requisição.
+ * 
+ * @name get/api/perfil/:id
+ * @function
+ * @memberof module:routes/liderancas
+ */
+router.post("/lista", (req, res) => {
+
+  console.log(req.body.parlamentares);
+
+  PerfilMais.findAll({
+    attributes: attPerfil,
+    include: [
+      {
+        attributes: attParlamentar,
+        model: Parlamentar,
+        as: "perfilMaisParlamentar",
+        include: [
+          {
+            attributes: attAderencia,
+            model: Aderencia,
+            as: "parlamentarAderencia",
+            required: false,
+            include: [
+              {
+                attributes: attPartido,
+                model: Partido,
+                as: "partido",
+                required: false,
+              },
+              {
+                attributes: attTema,
+                model: Tema,
+                as: "aderenciaTema",
+                required: false
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    where: {
+      id_parlamentar_voz: req.body.parlamentares
+    }
+  })
+    .then(parlamentares => res.status(SUCCESS).json(parlamentares))
+    .catch(err => res.status(BAD_REQUEST).json({ err }));
+});
+
+module.exports = router;

--- a/server.js
+++ b/server.js
@@ -18,6 +18,7 @@ const parlamentares = require("./routes/api/parlamentares");
 const aderencia = require("./routes/api/aderencia");
 const orientacoes = require("./routes/api/orientacoes");
 const liderancas = require("./routes/api/liderancas");
+const perfil = require("./routes/api/perfil");
 
 const app = express();
 app.use(forceSsl);
@@ -60,6 +61,7 @@ app.use("/api/parlamentares", parlamentares);
 app.use("/api/aderencia", aderencia);
 app.use("/api/orientacoes", orientacoes);
 app.use("/api/liderancas", liderancas);
+app.use("/api/perfil", perfil);
 
 // Set static folder
 app.use(express.static("client/build"));


### PR DESCRIPTION
## Changes
- Adiciona model para dados do perfil +
- Adiciona endpoints que retornam informações pedidas pelo [leggo.org.br](https://leggo.org.br)
  - Endpoint GET com informação por id (no Voz Ativa):  /api/perfil/:id
Exemplo de id: "1160508".
  - Endpoint POST com informação por lista de IDs (no VA): /api/perfil/lista
Exemplo de body:
```
{
"parlamentares": ["1160508", "1136811"]
}
```

## Flags
- Assume que o [PR](https://github.com/analytics-ufcg/vozativa-dados/pull/180) do módulo de dados foi revisado e aprovado.